### PR TITLE
make it possible to handle unkown property on SELECT PGQL

### DIFF
--- a/src/core/PgDatatypeConstants.ts
+++ b/src/core/PgDatatypeConstants.ts
@@ -11,6 +11,7 @@ interface JavaPgDatatypeConstants {
   TYPE_DT_INTEGER: number
   TYPE_DT_BOOL: number
   TYPE_DT_DATE: number
+  TYPE_DT_EMPTY: number
 }
 
 /**

--- a/src/parameter-handler.ts
+++ b/src/parameter-handler.ts
@@ -44,6 +44,8 @@ export class ParameterHandler implements IParameterHandler {
           case 'timestamp':
             pstmt.setTimestamp(p.index, p.value as LocalDateTime)
             break
+          case 'object':
+            throw new Error('object type is not supported on parameters')
           default:
             throw new Error(`${p.type} is not valid parameter type.`)
         }

--- a/src/result-handler.ts
+++ b/src/result-handler.ts
@@ -65,6 +65,8 @@ export class ResultHanlder implements IResultHanlder {
           return 'double'
         case PgDatatypeConstants.TYPE_DT_STRING:
           return 'string'
+        case PgDatatypeConstants.TYPE_DT_EMPTY:
+          return 'object'
         default:
           throw new Error(`unkown PGQL types: ${t}`)
       }
@@ -93,6 +95,8 @@ export class ResultHanlder implements IResultHanlder {
               return rs.getDouble(name)
             case PgDatatypeConstants.TYPE_DT_STRING:
               return rs.getString(name)
+            case PgDatatypeConstants.TYPE_DT_EMPTY:
+              return null
             default:
               throw new Error(`unkown PGQL types: ${t}`)
           }

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,7 @@ type PgqlTypeName =
   | 'double'
   | 'boolean'
   | 'timestamp'
+  | 'object'
 
 /**
  * TypeScript Type in PGQL


### PR DESCRIPTION
### 概要
#5 に対しての実装です。

### 変更点
- `PgDatatypeConstants` に `TYPE_DT_EMPTY` を追加
- `PgqlTypeName` に `object` を追加
- `ResultHanlder` で ResultSet を参照したときに `PgDatatypeConstants.TYPE_DT_EMPTY` が返ってくる場合に null を返すように修正
- `ParameterHandler` では、`object` タイプを設定した場合には Error が発生するようにした

